### PR TITLE
Use the relevant distro

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ install_core ()
 {
     echo "...installing the Sensu Core software repository..."
     wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | apt-key add - > /dev/null 2>&1
-    echo "deb     http://repositories.sensuapp.org/apt sensu main" | tee /etc/apt/sources.list.d/sensu.list > /dev/null 2>&1
+    echo "deb     http://repositories.sensuapp.org/apt $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/sensu.list > /dev/null 2>&1
     echo "SUCCESS!"
     success=1
 }


### PR DESCRIPTION
The hard-coded "sensu" distro does not contain the latest version (0.27) but the version-specific distros do. The install.sh script should use the packages for the specific version of Ubuntu.

Also, missing a line ending on the last line. :)